### PR TITLE
Expand cases where the plugin emits warnings

### DIFF
--- a/MediaWikiServicesCheckPlugin.php
+++ b/MediaWikiServicesCheckPlugin.php
@@ -67,13 +67,36 @@ class MediaWikiServicesVisitor extends PluginAwarePostAnalysisVisitor {
 			return;
 		}
 
+		if ( $this->emitSubclassBasedWarning() ) {
+			return;
+		}
+		if ( $this->checkHookHandler() ) {
+			return;
+		}
+	}
+
+	/**
+	 * Emit a warning if the class can have dependencies injected based on
+	 * being a special page, api module, or other component that supports DI.
+	 * Returns whether a warning was emitted or not.
+	 */
+	private function emitSubclassBasedWarning(): bool {
 		// Map of class to detect extending => placeholder for message
 		// The *FIRST* matching message is used, to allow for more specific
 		// messages
 		$baseClassMap = [
+			'\\MediaWiki\\SpecialPage\\SpecialPage' => 'Special pages',
+			'\\MediaWiki\\Api\\ApiQueryBase' => 'API query modules',
+			'\\MediaWiki\\Api\\ApiBase' => 'API modules',
+			'\\MediaWiki\\JobQueue\\Job' => 'Job classes',
+			'\\MediaWiki\\Content\\ContentHandler' => 'Content handlers',
+			'\\MediaWiki\\Rest\\Handler' => 'REST handlers',
+			// Legacy class aliases
 			'\\SpecialPage' => 'Special pages',
 			'\\ApiQueryBase' => 'API query modules',
 			'\\ApiBase' => 'API modules',
+			'\\Job' => 'Job classes',
+			'\\ContentHandler' => 'Content handlers',
 		];
 
 		$scope = $this->context->getScope();
@@ -91,8 +114,48 @@ class MediaWikiServicesVisitor extends PluginAwarePostAnalysisVisitor {
 				'%s should have services injected with dependency injection',
 				[ $msg ]
 			);
-			return;
+			return true;
 		}
+		return false;
+	}
+
+	/**
+	 * Emit a warning if the class can have dependencies injected as a hook
+	 * handler that supports DI. Returns whether a warning was emitted or not.
+	 */
+	private function checkHookHandler(): bool {
+		$scope = $this->context->getScope();
+
+		$clazz = $this->code_base->getClassByFQSEN( $scope->getClassFQSEN() );
+		$interfaceNames = array_map(
+			static fn ( $interface ) => $interface->getName(),
+			$clazz->getInterfaceFQSENList()
+		);
+		$hookInterfaces = array_filter(
+			$interfaceNames,
+			static fn ( $name ) => str_ends_with( $name, 'Hook' )
+		);
+
+		$noDIHooks = [
+			'LoadExtensionSchemaUpdatesHook',
+			'MediaWikiServicesHook',
+		];
+		$yesDIHooks = array_diff( $hookInterfaces, $noDIHooks );
+
+		if ( $yesDIHooks === [] ) {
+			return false;
+		}
+
+		$msg = 'Hook handlers should have services injected with dependency injection';
+		$noDIHooks = array_intersect( $hookInterfaces, $noDIHooks );
+		if ( $noDIHooks ) {
+			$msg .= '; the hooks that do not support DI can be split to a separate handler';
+		}
+		$this->emit(
+			'MediaWikiServicesAccessed',
+			$msg
+		);
+		return true;
 	}
 }
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 	],
 	"require": {
 		"phan/phan": "^5.4",
-		"php": ">=7.4.0"
+		"php": ">=7.4.0",
+		"symfony/polyfill-php80": "1.32.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "43.0.0",

--- a/tests/cases/Api/NSNormalApi.php
+++ b/tests/cases/Api/NSNormalApi.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Example;
+
+use MediaWiki\Api\ApiBase;
+use MediaWiki\MediaWikiServices;
+
+class NSNormalApi extends ApiBase {
+
+	public function test1( $par ) {
+		// getService() with arbitrary service name
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $par );
+	}
+
+}

--- a/tests/cases/Api/NSQueryApi.php
+++ b/tests/cases/Api/NSQueryApi.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Example;
+
+use MediaWiki\Api\ApiQueryBase;
+use MediaWiki\MediaWikiServices;
+
+class NSQueryApi extends ApiQueryBase {
+
+	public function test1( $par ) {
+		// getService() with arbitrary service name
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $par );
+	}
+
+}

--- a/tests/cases/Api/expected.txt
+++ b/tests/cases/Api/expected.txt
@@ -1,2 +1,4 @@
+cases/Api/NSNormalApi.php:12 MediaWikiServicesAccessed API modules should have services injected with dependency injection
+cases/Api/NSQueryApi.php:12 MediaWikiServicesAccessed API query modules should have services injected with dependency injection
 cases/Api/NormalApi.php:9 MediaWikiServicesAccessed API modules should have services injected with dependency injection
 cases/Api/QueryApi.php:9 MediaWikiServicesAccessed API query modules should have services injected with dependency injection

--- a/tests/cases/ContentHandler/MyHandler.php
+++ b/tests/cases/ContentHandler/MyHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+use MediaWiki\MediaWikiServices;
+
+class MyHandler extends ContentHandler {
+
+	public function __construct() {
+		parent::__construct( 'text', [ 'text/plain' ] );
+	}
+
+	public function run() {
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $this );
+	}
+
+}

--- a/tests/cases/ContentHandler/NSMyHandler.php
+++ b/tests/cases/ContentHandler/NSMyHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Example;
+
+use MediaWiki\Content\ContentHandler;
+use MediaWiki\MediaWikiServices;
+
+class NSMyHandler extends ContentHandler {
+
+	public function __construct() {
+		parent::__construct( 'text', [ 'text/plain' ] );
+	}
+
+	public function run() {
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $this );
+	}
+
+}

--- a/tests/cases/ContentHandler/expected.txt
+++ b/tests/cases/ContentHandler/expected.txt
@@ -1,0 +1,2 @@
+cases/ContentHandler/MyHandler.php:12 MediaWikiServicesAccessed Content handlers should have services injected with dependency injection
+cases/ContentHandler/NSMyHandler.php:15 MediaWikiServicesAccessed Content handlers should have services injected with dependency injection

--- a/tests/cases/Hooks/JustDIHook.php
+++ b/tests/cases/Hooks/JustDIHook.php
@@ -1,0 +1,13 @@
+<?php
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Output\Hook\BeforePageDisplayHook;
+
+class JustDIHook implements BeforePageDisplayHook {
+
+	public function onBeforePageDisplay( $out, $skin ): void {
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $out, $skin );
+	}
+
+}

--- a/tests/cases/Hooks/MixedHooks.php
+++ b/tests/cases/Hooks/MixedHooks.php
@@ -1,0 +1,19 @@
+<?php
+
+use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Output\Hook\BeforePageDisplayHook;
+
+class MixedHooks implements BeforePageDisplayHook, LoadExtensionSchemaUpdatesHook {
+
+	public function onBeforePageDisplay( $out, $skin ): void {
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $out, $skin );
+	}
+
+	public function onLoadExtensionSchemaUpdates( $updater ) {
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $updater );
+	}
+
+}

--- a/tests/cases/Hooks/expected.txt
+++ b/tests/cases/Hooks/expected.txt
@@ -1,0 +1,3 @@
+cases/Hooks/JustDIHook.php:9 MediaWikiServicesAccessed Hook handlers should have services injected with dependency injection
+cases/Hooks/MixedHooks.php:10 MediaWikiServicesAccessed Hook handlers should have services injected with dependency injection; the hooks that do not support DI can be split to a separate handler
+cases/Hooks/MixedHooks.php:15 MediaWikiServicesAccessed Hook handlers should have services injected with dependency injection; the hooks that do not support DI can be split to a separate handler

--- a/tests/cases/Jobs/MyJob.php
+++ b/tests/cases/Jobs/MyJob.php
@@ -1,0 +1,16 @@
+<?php
+
+use MediaWiki\MediaWikiServices;
+
+class MyJob extends Job {
+
+	public function __construct( $title, $params = [] ) {
+		parent::__construct( 'example', $title, $params );
+	}
+
+	public function run() {
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $this );
+	}
+
+}

--- a/tests/cases/Jobs/NSMyJob.php
+++ b/tests/cases/Jobs/NSMyJob.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Example;
+
+use MediaWiki\JobQueue\Job;
+use MediaWiki\MediaWikiServices;
+
+class NSMyJob extends Job {
+
+	public function __construct( $title, $params = [] ) {
+		parent::__construct( 'example', $title, $params );
+	}
+
+	public function run() {
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $this );
+	}
+
+}

--- a/tests/cases/Jobs/expected.txt
+++ b/tests/cases/Jobs/expected.txt
@@ -1,0 +1,2 @@
+cases/Jobs/MyJob.php:12 MediaWikiServicesAccessed Job classes should have services injected with dependency injection
+cases/Jobs/NSMyJob.php:15 MediaWikiServicesAccessed Job classes should have services injected with dependency injection

--- a/tests/cases/Rest/MyHandler.php
+++ b/tests/cases/Rest/MyHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Rest\Handler;
+
+class MyHandler extends Handler {
+
+	public function execute() {
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( 123 );
+	}
+
+}

--- a/tests/cases/Rest/expected.txt
+++ b/tests/cases/Rest/expected.txt
@@ -1,0 +1,1 @@
+cases/Rest/MyHandler.php:9 MediaWikiServicesAccessed REST handlers should have services injected with dependency injection

--- a/tests/cases/SpecialPage/NSFormSpecial.php
+++ b/tests/cases/SpecialPage/NSFormSpecial.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Example;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\SpecialPage\FormSpecialPage;
+
+class NSFormSpecial extends FormSpecialPage {
+
+	public function test1( $par ) {
+		// getService() with arbitrary service name
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $par );
+	}
+
+}

--- a/tests/cases/SpecialPage/NSMySpecial.php
+++ b/tests/cases/SpecialPage/NSMySpecial.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Example;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\SpecialPage\SpecialPage;
+
+class NSMySpecial extends SpecialPage {
+
+	public function test1( $par ) {
+		// getService() with arbitrary service name
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $par );
+	}
+
+	public function test2( $par ) {
+		// get() with arbitrary service name
+		$service = MediaWikiServices::getInstance()->get( 'MyService' );
+		$service->run( $par );
+	}
+
+	public function test3( $par ) {
+		// service-specific getter
+		$service = MediaWikiServices::getInstance()->getUserFactory();
+		$service->run( $par );
+	}
+
+}

--- a/tests/cases/SpecialPage/expected.txt
+++ b/tests/cases/SpecialPage/expected.txt
@@ -2,3 +2,7 @@ cases/SpecialPage/FormSpecial.php:9 MediaWikiServicesAccessed Special pages shou
 cases/SpecialPage/MySpecial.php:9 MediaWikiServicesAccessed Special pages should have services injected with dependency injection
 cases/SpecialPage/MySpecial.php:15 MediaWikiServicesAccessed Special pages should have services injected with dependency injection
 cases/SpecialPage/MySpecial.php:21 MediaWikiServicesAccessed Special pages should have services injected with dependency injection
+cases/SpecialPage/NSFormSpecial.php:12 MediaWikiServicesAccessed Special pages should have services injected with dependency injection
+cases/SpecialPage/NSMySpecial.php:12 MediaWikiServicesAccessed Special pages should have services injected with dependency injection
+cases/SpecialPage/NSMySpecial.php:18 MediaWikiServicesAccessed Special pages should have services injected with dependency injection
+cases/SpecialPage/NSMySpecial.php:24 MediaWikiServicesAccessed Special pages should have services injected with dependency injection

--- a/tests/cases/ValidUsage/HookNoDI.php
+++ b/tests/cases/ValidUsage/HookNoDI.php
@@ -1,0 +1,13 @@
+<?php
+
+use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
+use MediaWiki\MediaWikiServices;
+
+class HookNoDI implements LoadExtensionSchemaUpdatesHook {
+
+	public function onLoadExtensionSchemaUpdates( $updater ) {
+		$service = MediaWikiServices::getInstance()->getService( 'MyService' );
+		$service->run( $updater );
+	}
+
+}

--- a/tests/stubs/BaseClasses.php
+++ b/tests/stubs/BaseClasses.php
@@ -1,16 +1,71 @@
 <?php
 
 // Stubs for testing
-class SpecialPage {
 
-	public function __construct($a, $b) {
+namespace MediaWiki\SpecialPage {
+
+	class SpecialPage {
+
+		public function __construct( $a, $b ) {
+		}
 	}
+
+	// For confirming that sub-sub classes also work
+	class FormSpecialPage extends SpecialPage {
+	}
+
+	class_alias( SpecialPage::class, 'SpecialPage' );
+	class_alias( FormSpecialPage::class, 'FormSpecialPage' );
+
 }
 
-// For confirming that sub-sub classes also work
-class FormSpecialPage extends SpecialPage {}
+namespace MediaWiki\Api {
 
-class ApiBase {}
+	class ApiBase {
+	}
 
-class ApiQueryBase extends ApiBase {}
+	class ApiQueryBase extends ApiBase {
+	}
 
+	class_alias( ApiBase::class, 'ApiBase' );
+	class_alias( ApiQueryBase::class, 'ApiQueryBase' );
+
+}
+
+namespace MediaWiki\JobQueue {
+
+	abstract class Job {
+
+		public function __construct( ...$all ) {
+		}
+
+		abstract public function run();
+
+	}
+
+	class_alias( Job::class, 'Job' );
+
+}
+
+namespace MediaWiki\Content {
+
+	class ContentHandler {
+
+		public function __construct( $modelId, $formats ) {
+		}
+
+	}
+
+	class_alias( ContentHandler::class, 'ContentHandler' );
+
+}
+
+namespace MediaWiki\Rest {
+
+	abstract class Handler {
+
+		abstract public function execute();
+
+	}
+
+}

--- a/tests/stubs/Hooks.php
+++ b/tests/stubs/Hooks.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace MediaWiki\Output\Hook {
+
+	interface BeforePageDisplayHook {
+
+		public function onBeforePageDisplay( $out, $skin ): void;
+
+	}
+
+	class_alias( BeforePageDisplayHook::class, 'MediaWiki\Hook\BeforePageDisplayHook' );
+
+}
+
+namespace MediaWiki\Installer\Hook {
+
+	interface LoadExtensionSchemaUpdatesHook {
+
+		public function onLoadExtensionSchemaUpdates( $updater );
+	}
+
+}

--- a/tests/test-config.php
+++ b/tests/test-config.php
@@ -13,4 +13,7 @@ $cfg['suppress_issue_types'] = [
 	'PhanNonClassMethodCall',
 ];
 
+// For testing aliases
+$cfg['enable_class_alias_support'] = true;
+
 return $cfg;


### PR DESCRIPTION
Add support for the namespaced versions of the existing classes:
- `\SpecialPage` -> `\MediaWiki\SpecialPage\SpecialPage`
- `\ApiBase` -> `\MediaWiki\Api\ApiBase`
- `\ApiQueryBase` -> `\MediaWiki\Api\ApiQueryBase`

Add support for more components that support DI:
- `\MediaWiki\JobQueue\Job` (and `\Job`) subclasses
- `\MediaWiki\Content\ContentHandler` (and `\ContentHandler`) subclasses
- `\MediaWiki\Rest\Handler` subclasses

Add support for hook handlers, detected based on the following logic:
- If a class implements one or more interface that ends in "Hook", it is a hook handler
- If the class implements at least one of the core hooks that do not support service injection (LoadExtensionSchemaUpdates or MediaWikiServices) as well as hooks that support DI, the warning message suggests that DI be used and that the hook handler be split up
- If the class implements neither of those two hooks but does implement other hooks, a warning message suggests using DI
- If the class implements no hooks that support DI, no warning message is shown

SEL-2323