### PR TITLE
Relax `symfony/polyfill-php80` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	"require": {
 		"phan/phan": "^5.4",
 		"php": ">=7.4.0",
-		"symfony/polyfill-php80": "1.32.0"
+		"symfony/polyfill-php80": "^1.16.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "43.0.0",


### PR DESCRIPTION
Core 1.43 requires version 1.31.0 of the polyfill

SEL-2323